### PR TITLE
remove trailing whitespace on visual selection for going to step defi…

### DIFF
--- a/autoload/behave.py
+++ b/autoload/behave.py
@@ -4,7 +4,7 @@ import sys
 import os
 
 def get_step_definition(feature, input):
-    parsed_input = " ".join(input.lstrip().split(" ")[1:]).lstrip()
+    parsed_input = " ".join(input.strip().split(" ")[1:]).lstrip()
     base_path = os.path.dirname(os.path.abspath(feature))
     steps_paths = [os.path.join(base_path, "steps")]
 


### PR DESCRIPTION
Hello! So when finding a step definition, if it has a trailing whitespace it will not find the step. I noticed here you're only stripping the leading whitespace. Therefore, if I select a step line in Visual Line mode, and I forgot to delete a space at the end, it will not find the definition. I was confused for awhile why this plugin was having trouble finding one of my steps. Is this specificity of only stripping the leading whitespace intentional? Let me know if I'm off here, just thought I would check.